### PR TITLE
[feature] task executor: support runtime picking and reconfiguration

### DIFF
--- a/docs/task_executor.md
+++ b/docs/task_executor.md
@@ -25,3 +25,11 @@ Mount the config file at `/app/meca_executor.yaml`
 ```sh
 docker run -it --name meca_executor_test -v /var/run/docker.sock:/var/run/docker.sock -v <your-config-file>:/app/meca_executor.yaml --net=meca --ip=172.18.0.255 meca-executor:latest
 ```
+
+Reconfiguration is supported by pausing the executor and passing a new executor configuration file. Currently we the executor type field is ignored, since only docker is supported.
+
+```sh
+curl http://172.18.0.255:2591/pause -X POST
+curl http://172.18.0.255:2591/update-config -X POST -H "Content-Type: application/json" -d '{"timeout": 2, "cpu":2, "mem":4096, "microVM_runtime":"kata"}'
+curl http://172.18.0.255:2591/unpause -X POST
+```

--- a/task_executor/README.md
+++ b/task_executor/README.md
@@ -54,11 +54,17 @@ curl http://localhost:2591 -X POST -H "Content-Type: application/json" -d '{"id"
 Retrieve stats
 
 ```sh
-curl http://172.18.0.255:259/stats -X POST
+curl http://172.18.0.255:2591/stats -X POST
 ```
 
 Provide resource limit for the task
 
 ```sh
-curl http://172.18.0.255:259 -X POST -H "Content-Type: application/json" -d '{"id": "hugy718/goserver:v2", "resource": {"cpu":2, "mem":256}, "input": "{\"name\": \"sbip\"}"}'
+curl http://172.18.0.255:2591 -X POST -H "Content-Type: application/json" -d '{"id": "hugy718/goserver:v2", "resource": {"cpu":2, "mem":256}, "input": "{\"name\": \"sbip\"}"}'
+```
+
+Pick the microVM runtime if the host has it.
+
+```sh
+curl http://172.18.0.255:2591 -X POST -H "Content-Type: application/json" -d '{"id": "hugy718/sample:v1","runtime": "microVM", "resource": {"cpu":1, "mem":128}, "input": "{\"name\": \"sbip\"}"}'
 ```

--- a/task_executor/app/main.go
+++ b/task_executor/app/main.go
@@ -130,7 +130,7 @@ func main() {
 	router.POST("/stop", meca_stop)
 	router.POST("/pause", meca_pause)
 	router.POST("/unpause", meca_unpause)
-	router.POST("/stats", meca_stats)
+	router.GET("/stats", meca_stats)
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})

--- a/task_executor/conf/meca_docker_kata.yaml
+++ b/task_executor/conf/meca_docker_kata.yaml
@@ -1,0 +1,7 @@
+# now only support docker
+type: "docker"
+# timeout in minutes
+timeout: 1
+cpu: 2
+mem: 2048
+microVM_runtime: kata

--- a/task_executor/config.go
+++ b/task_executor/config.go
@@ -27,3 +27,10 @@ func ParseMecaExecutorConfig(filename string) (MecaExecutorConfig, error) {
 	}
 	return cfg, nil
 }
+
+type MecaExecutorConfigReq struct {
+	Timeout        int     `json:"timeout"`
+	Cpu            float64 `json:"cpu" binding:"required,gt=0.0"`
+	Mem            int     `json:"mem" binding:"required,gt=0"`
+	MicroVMRuntime string  `json:"microVM_runtime"`
+}

--- a/task_executor/config.go
+++ b/task_executor/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type MecaExecutorConfig struct {
-	Type    string  `yaml:"type"`
-	Timeout int     `yaml:"timeout"`
-	Cpu     float64 `yaml:"cpu"`
-	Mem     int     `yaml:"mem"`
+	Type           string  `yaml:"type"`
+	Timeout        int     `yaml:"timeout"`
+	Cpu            float64 `yaml:"cpu"`
+	Mem            int     `yaml:"mem"`
+	MicroVMRuntime string  `yaml:"microVM_runtime"`
 }
 
 func ParseMecaExecutorConfig(filename string) (MecaExecutorConfig, error) {

--- a/task_executor/docker/Dockerfile
+++ b/task_executor/docker/Dockerfile
@@ -24,5 +24,9 @@ WORKDIR /app
 # Expose a port if your application listens on a specific port
 EXPOSE 8080
 
+RUN apk add --no-cache tini
+# Tini is now available at /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 # Run the Go application when the container starts
-CMD ./app -config ./meca_executor.yaml
+CMD ["./app", "-config", "./meca_executor.yaml"]

--- a/task_executor/executor.go
+++ b/task_executor/executor.go
@@ -127,11 +127,13 @@ func (t *taskTracker) clean(timeout int) {
 }
 
 type MecaExecutor struct {
-	timeout           int
-	tracker           *taskTracker
-	rm                ResourceManager
-	repo              TaskRepo
-	fac               TaskFactory
+	timeout  int
+	tracker  *taskTracker
+	rm       ResourceManager
+	repo     TaskRepo
+	fac      TaskFactory
+	runtimes map[string]string // map the meca runtime tag to the corresponding runtime name specified by host
+
 	started           bool
 	stopped           atomic.Bool
 	stopChn           chan<- struct{}
@@ -228,7 +230,7 @@ func (meca *MecaExecutor) Stats() ResourceStats {
 	return meca.rm.Stats()
 }
 
-func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc ResourceLimit, input []byte) ([]byte, error) {
+func (meca *MecaExecutor) Execute(ctx context.Context, taskCfg TaskConfig, input []byte) ([]byte, error) {
 	if meca == nil {
 		return nil, errInvalidMecaExecutor
 	}
@@ -238,17 +240,27 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 	}
 
 	// validate and tidy the resource limit
-	if rsrc.isEmpty() {
-		rsrc = getDefaultResourceLimit()
+	if taskCfg.Rsrc.isEmpty() {
+		taskCfg.Rsrc = getDefaultResourceLimit()
+	}
+
+	// translate the runtime type
+	if len(taskCfg.Runtime) > 0 {
+		if rt, ok := meca.runtimes[taskCfg.Runtime]; !ok {
+			log.Printf("unknown runtime %s, using docker default", taskCfg.Runtime)
+		} else {
+			log.Printf("using runtime %s -> %s", taskCfg.Runtime, rt)
+			taskCfg.Runtime = rt
+		}
 	}
 
 	// ensure the task uses correct version of image
 	// TODO (expose more control for version later)
 	imageUpdate := false
-	if found, err := meca.repo.Exists(imageId, ""); err != nil && err != errUnFoundImageVersion {
+	if found, err := meca.repo.Exists(taskCfg.ImageId, ""); err != nil && err != errUnFoundImageVersion {
 		return nil, err
 	} else if !found {
-		if err := meca.repo.Fetch(imageId, "", ""); err != nil {
+		if err := meca.repo.Fetch(taskCfg.ImageId, "", ""); err != nil {
 			return nil, err
 		}
 		imageUpdate = true
@@ -259,10 +271,10 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 	// TODO: when id is not uid for an image (using image tag), we should construct uid for task id here, and release the old task handle under the old uid
 
 	// get the taskid as key for tracker.
-	taskId := GetTaskId(imageId, rsrc)
+	taskId := GetTaskId(taskCfg)
 
 	if imageUpdate {
-		task, err := meca.fac.Build(imageId, rsrc)
+		task, err := meca.fac.Build(taskId, taskCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -277,7 +289,7 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 			break
 		}
 		log.Printf("adding task")
-		task, err := meca.fac.Build(imageId, rsrc)
+		task, err := meca.fac.Build(taskId, taskCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -293,7 +305,7 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 		h.initMu.Lock()
 		if !h.initialized.Load() {
 			// reserve the resources
-			if err := meca.rm.Reserve(float64(rsrc.CPU), int(rsrc.MEM)); err != nil {
+			if err := meca.rm.Reserve(float64(taskCfg.Rsrc.CPU), int(taskCfg.Rsrc.MEM)); err != nil {
 				h.initMu.Unlock()
 				return nil, err
 			}
@@ -303,8 +315,8 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 			for {
 				if err = h.task.Init(ctx, "", port); err == nil {
 					// register release callback when the task init successfully
-					releaseCpu := float64(rsrc.CPU)
-					releaseMem := int(rsrc.MEM)
+					releaseCpu := float64(taskCfg.Rsrc.CPU)
+					releaseMem := int(taskCfg.Rsrc.MEM)
 					h.releaseCb = func() error {
 						return meca.rm.Release(releaseCpu, releaseMem)
 					}
@@ -312,7 +324,7 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 					break
 				} else if retryCount > 10 {
 					// init failed, release resources
-					meca.rm.Release(float64(rsrc.CPU), int(rsrc.MEM))
+					meca.rm.Release(float64(taskCfg.Rsrc.CPU), int(taskCfg.Rsrc.MEM))
 					break
 				}
 				retryCount++
@@ -324,6 +336,6 @@ func (meca *MecaExecutor) Execute(ctx context.Context, imageId string, rsrc Reso
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("task %v (CPU: %d core, MEM %dMB) added: %v ", imageId, rsrc.CPU, rsrc.MEM, h.task)
+	log.Printf("task with config %v added: %v ", taskCfg, h.task)
 	return h.task.Execute(ctx, input)
 }

--- a/task_executor/go.mod
+++ b/task_executor/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/gin-gonic/gin v1.9.1
 	github.com/shirou/gopsutil/v3 v3.23.7
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -43,6 +44,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
@@ -54,6 +56,5 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.0 // indirect
 )

--- a/task_executor/go.sum
+++ b/task_executor/go.sum
@@ -79,7 +79,9 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/shirou/gopsutil/v3 v3.23.7 h1:C+fHO8hfIppoJ1WdsVm1RoI0RwXoNdfTK7yWXV0wVj4=
 github.com/shirou/gopsutil/v3 v3.23.7/go.mod h1:c4gnmoRC0hQuaLqvxnx1//VXQ0Ms/X9UnJF8pddY5z4=
+github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
This PR adds two features to task executor 
1. enables the task to be executed with a microVM runtime, which will be translated to the docker runtime registered by the host for that. Currently, we tested with Kata-container support with docker.
2. expose the reconfiguration handle
And it also include other changes
1. use pause rw mutex to guard the reconfiguration, requiring `Execute` and `Stats` to hold the read lock.
2. change the `/stats` handle from post to get
3. add `tini` to the task executor docker to reap zombie processes
4. add parameter requirement for execute request to supply image id and reconfiguration with at least both cpu and memory values; return bad request message on `/` and `/update-config`. 